### PR TITLE
Update Cargo.toml to include `khronos_api`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,8 @@ path = "src/lib.rs"
 [build-dependencies.gl_generator]
 git = "https://github.com/bjz/gl-rs.git"
 
+[build-dependencies.khronos_api]
+version = "0.0.5"
+
 [dependencies.gl_common]
 git = "https://github.com/bjz/gl-rs.git"


### PR DESCRIPTION
This seems to be the blocking build issue for this package.