### PR TITLE
Update to gl_generator 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,8 @@ name = "gfx_gl"
 path = "src/lib.rs"
 
 [build-dependencies]
-gl_generator = "0.2"
+gl_generator = "0.3"
 khronos_api = "0.0"
 
 [dependencies]
 gl_common = "0.1"
-libc = "0.2"


### PR DESCRIPTION
gl_generator has switched from libc::c_void to std::os::raw::c_void in
the generated code, so the libc dependency is no longer needed.