### PR TITLE
Update to gl_generator 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ name = "gfx_gl"
 path = "src/lib.rs"
 
 [build-dependencies]
-gl_generator = "0.3"
+gl_generator = "0.4"
 khronos_api = "0.0"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 
 name = "gfx_gl"
-version = "0.2.0"
+version = "0.3.0"
 build = "build.rs"
 description = "OpenGL bindings for gfx, based on gl-rs"
 homepage = "https://github.com/gfx-rs/gfx_gl"


### PR DESCRIPTION
Version 0.4 of gl_generator does not depend on libc and contains fixes to GLvoid type that broke gfx builds with gl_generator 0.3.

Bumping this crate version will allow this change to be propagated to gfx_device_gl and allow it to drop libc dependency as well.