### PR TITLE
Adjust khronos_api and gl_common dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,3 @@ path = "src/lib.rs"
 [build-dependencies]
 gl_generator = "0.4"
 khronos_api = "1.0"
-
-[dependencies]
-gl_common = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ path = "src/lib.rs"
 
 [build-dependencies]
 gl_generator = "0.4"
-khronos_api = "0.0"
+khronos_api = "1.0"
 
 [dependencies]
 gl_common = "0.1"


### PR DESCRIPTION
In attempts to not compile multiple versions of dependencies (khronos_api 0.0.8 / 1.0.0, libc 0.1.x / 0.2.x), raise khronos_api to "1.0" in Cargo.toml and remove gl_common. The gl_common situation is unclear but  consider this: [https://github.com/bjz/gl-rs/pull/359 "Remove the gl_common crate #359"] (https://github.com/bjz/gl-rs/pull/359). gfx_gl displays no visible build errors when not depending on gl_common.