### PR TITLE
Update khronos api and remove gl_common.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 
 name = "gfx_gl"
-version = "0.3.0"
+version = "0.3.1"
 build = "build.rs"
 description = "OpenGL bindings for gfx, based on gl-rs"
 homepage = "https://github.com/gfx-rs/gfx_gl"
@@ -29,7 +29,4 @@ path = "src/lib.rs"
 
 [build-dependencies]
 gl_generator = "0.4"
-khronos_api = "0.0"
-
-[dependencies]
-gl_common = "0.1"
+khronos_api = "1.0"


### PR DESCRIPTION
Proposing this again after some more thought and testing.

First, the khronos_api version update is self explanatory; the new version 1.0.0 exists.

Next, regarding the removal of gl_common, the initial motivation was to prevent the gfx crate from compiling both libc 0.2.x and libc 0.1.x.
It was observed that gfx depended on gfx_gl which depended on gl_common.
The idea that gl_common might be unnecessary came when reading this: [https://github.com/bjz/gl-rs/pull/359 "Remove the gl_common crate #359"] (https://github.com/bjz/gl-rs/pull/359).

The gfx crate depends on gfx_gl so to test these changes the following actions were performed on gfx:
cargo build
cargo run --example triangle
cargo run --example cube
cargo run --example deferred
All of the above built successfully and the examples ran successfully.