### PR TITLE
Update gl_generate to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,4 @@ name = "gfx_gl"
 path = "src/lib.rs"
 
 [build-dependencies]
-gl_generator = "0.5"
+gl_generator = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 
 name = "gfx_gl"
-version = "0.3.2"
+version = "0.4.0"
 build = "build.rs"
 description = "OpenGL bindings for gfx, based on gl-rs"
 homepage = "https://github.com/gfx-rs/gfx_gl"


### PR DESCRIPTION
This is required for projects using gfx_gl to be run when compiled with release flag using nightly version of rustc starting with 19. november 2k17.

https://github.com/brendanzab/gl-rs/issues/438