### PR TITLE
Add S3TC extensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ name = "gfx_gl"
 path = "src/lib.rs"
 
 [build-dependencies]
-gl_generator = "0.9"
+gl_generator = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "gfx_gl"
-version = "0.5.0"
+version = "0.6.0"
 build = "build.rs"
 description = "OpenGL bindings for gfx, based on gl-rs"
 homepage = "https://github.com/gfx-rs/gfx_gl"

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,7 @@
 extern crate gl_generator;
 
-use gl_generator::{Registry, Api, Profile, Fallbacks};
-use std::env;
-use std::fs::File;
-use std::path::Path;
+use gl_generator::{Api, Fallbacks, Profile, Registry};
+use std::{env, fs::File, path::Path};
 
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
@@ -12,11 +10,19 @@ fn main() {
 
     let mut file = File::create(&dest.join("gl_bindings.rs")).unwrap();
 
-    Registry::new(Api::Gl, (4, 6), Profile::Core, Fallbacks::All, [
-        "GL_EXT_texture_filter_anisotropic",
-        "GL_ARB_draw_buffers_blend",
-        "GL_ARB_program_interface_query",
-        ])
-        .write_bindings(gl_generator::StructGenerator, &mut file)
-        .unwrap();
+    Registry::new(
+        Api::Gl,
+        (4, 6),
+        Profile::Core,
+        Fallbacks::All,
+        [
+            "GL_EXT_texture_filter_anisotropic",
+            "GL_ARB_draw_buffers_blend",
+            "GL_ARB_program_interface_query",
+            "GL_EXT_texture_compression_s3tc",
+            "GL_EXT_texture_sRGB",
+        ],
+    )
+    .write_bindings(gl_generator::StructGenerator, &mut file)
+    .unwrap();
 }


### PR DESCRIPTION
This update brings `gl_generator` up to date and adds extensions:
* `GL_EXT_texture_compression_s3tc`
* `GL_EXT_texture_sRGB`

Required/justified by https://github.com/gfx-rs/gfx/pull/2733